### PR TITLE
Functional suggestions from PR #4 

### DIFF
--- a/src/Serilog.Sinks.Map/MapLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Map/MapLoggerConfigurationExtensions.cs
@@ -21,15 +21,6 @@ using Serilog.Sinks.Map;
 namespace Serilog
 {
     /// <summary>
-    /// A function delegate to select a key value given a log event, if exists.
-    /// </summary>
-    /// <typeparam name="TKey">The type of the key value.</typeparam>
-    /// <param name="logEvent">The log event.</param>
-    /// <param name="key">The selected key.</param>
-    /// <returns>true, if a key can be selected, or false, otherwise.</returns>
-    public delegate bool KeySelector<TKey>(LogEvent logEvent, out TKey key);
-
-    /// <summary>
     /// Extends Serilog configuration with methods for selecting sink instances base on a log event property.
     /// </summary>
     public static class MapLoggerConfigurationExtensions
@@ -52,8 +43,8 @@ namespace Serilog
         public static LoggerConfiguration Map(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string keyPropertyName,
-            Action<string, LoggerSinkConfiguration> configure,
             string defaultKey,
+            Action<string, LoggerSinkConfiguration> configure,
             int? sinkMapCountLimit = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)
@@ -88,8 +79,8 @@ namespace Serilog
         public static LoggerConfiguration Map<TKey>(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             string keyPropertyName,
-            Action<TKey, LoggerSinkConfiguration> configure,
             TKey defaultKey,
+            Action<TKey, LoggerSinkConfiguration> configure,
             int? sinkMapCountLimit = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)

--- a/src/Serilog.Sinks.Map/Sinks/Map/MappedSink`1.cs
+++ b/src/Serilog.Sinks.Map/Sinks/Map/MappedSink`1.cs
@@ -20,6 +20,15 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Map
 {
+    /// <summary>
+    /// A function delegate to select a key value given a log event, if exists.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key value.</typeparam>
+    /// <param name="logEvent">The log event.</param>
+    /// <param name="key">The selected key.</param>
+    /// <returns>true, if a key can be selected, or false, otherwise.</returns>
+    public delegate bool KeySelector<TKey>(LogEvent logEvent, out TKey key);
+
     class MappedSink<TKey> : ILogEventSink, IDisposable
     {
         readonly KeySelector<TKey> _keySelector;

--- a/test/Serilog.Sink.Map.Tests/MappedSinkTests.cs
+++ b/test/Serilog.Sink.Map.Tests/MappedSinkTests.cs
@@ -231,7 +231,7 @@ namespace Serilog.Sinks.Map.Tests
             var received = new List<(string, LogEvent)>();
 
             var log = new LoggerConfiguration()
-                .WriteTo.Map("Name", (name, wt) => wt.Sink(new DelegatingSink(e => received.Add((name, e)))), defaultKey: "anonymous")
+                .WriteTo.Map("Name", "anonymous",(name, wt) => wt.Sink(new DelegatingSink(e => received.Add((name, e)))))
                 .CreateLogger();
 
             log.Write(a);


### PR DESCRIPTION
**What issue does this PR address?**
Functional suggestions from [#4](https://github.com/serilog/serilog-sinks-map/pull/4):
 - Added custom `bool KeySelector<TKey>(LogEvent logEvent, out TKey key)` delegate. New `Map` extension methods where added.
 - Non-generic `Map` extension method is less restrictive on `key` type for better usability: it takes `.ToString()` on any key value.
 - Fixed `NullReferenceTypeKeysAreSupported` test

**Does this PR introduce a breaking change?**
Yes, method signatures where changed for methods with `defaultKey`'s. They are required now. For new methods without `defaultKey`'s behavior is different from what was before.

**Please check if the PR fulfills these requirements**
- [x] the commit follows our guidelines
- [x] unit tests for the changes have been added

 


 