### PR TITLE
Final review 😁

### DIFF
--- a/src/Serilog.Sinks.Map/MapLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Map/MapLoggerConfigurationExtensions.cs
@@ -30,8 +30,9 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerSinkConfiguration">The logger sink configuration.</param>
         /// <param name="keyPropertyName">The name of a scalar-valued property to use as a sink selector.</param>
+        /// <param name="defaultKey">The key value to use when the property is missing or <code>null</code>.
+        /// A <code>null</code> default is allowed.</param>
         /// <param name="configure">An action to configure the target sink given a key property value.</param>
-        /// <param name="defaultKey">The key property value to use when no appropriate value is attached to the log event.</param>
         /// <param name="sinkMapCountLimit">Limits the number of sinks that will be held open concurrently within the map.
         /// The default is to let the map grow unbounded; smaller numbers will cause sinks to be evicted when the limit is
         /// exceeded. To keep no sinks open, zero may be specified.</param>
@@ -54,7 +55,7 @@ namespace Serilog
                 if (le.Properties.TryGetValue(keyPropertyName, out var v) &&
                     v is ScalarValue sv)
                 {
-                    return sv.Value?.ToString();
+                    return sv.Value?.ToString() ?? defaultKey;
                 }
 
                 return defaultKey;

--- a/src/Serilog.Sinks.Map/Serilog.Sinks.Map.csproj
+++ b/src/Serilog.Sinks.Map/Serilog.Sinks.Map.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Serilog sink wrapper that dispatches events based on a property value</Description>
+    <Description>A Serilog sink wrapper that dispatches events based on a property value.</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
     <RootNamespace>Serilog</RootNamespace>
     <Authors>Serilog Contributors</Authors>
-    <Copyright>Copyright © Serilog Contributors 2017</Copyright>
-    <TargetFrameworks>netstandard1.0</TargetFrameworks>
+    <Copyright>Copyright © Serilog Contributors 2017-2019</Copyright>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Map</AssemblyName>
@@ -24,7 +24,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sink.Map.Tests/MappedSinkTests.cs
+++ b/test/Serilog.Sink.Map.Tests/MappedSinkTests.cs
@@ -231,7 +231,41 @@ namespace Serilog.Sinks.Map.Tests
             var received = new List<(string, LogEvent)>();
 
             var log = new LoggerConfiguration()
-                .WriteTo.Map("Name", "anonymous",(name, wt) => wt.Sink(new DelegatingSink(e => received.Add((name, e)))))
+                .WriteTo.Map("Name", "anonymous", (name, wt) => wt.Sink(new DelegatingSink(e => received.Add((name, e)))))
+                .CreateLogger();
+
+            log.Write(a);
+
+            Assert.Single(received);
+            Assert.Equal("anonymous", received[0].Item1);
+        }
+
+        [Fact]
+        public void DefaultKeyIsUsedWhenNullValueIsAttachedToLogEvent()
+        {
+            var a = Some.LogEvent("Hello, {Name}!", (object)null);
+
+            var received = new List<(string, LogEvent)>();
+
+            var log = new LoggerConfiguration()
+                .WriteTo.Map("Name", "anonymous", (name, wt) => wt.Sink(new DelegatingSink(e => received.Add((name, e)))))
+                .CreateLogger();
+
+            log.Write(a);
+
+            Assert.Single(received);
+            Assert.Equal("anonymous", received[0].Item1);
+        }
+
+        [Fact]
+        public void DefaultKeyIsUsedWhenGenericNullValueIsAttachedToLogEvent()
+        {
+            var a = Some.LogEvent("Hello, {Name}!", (object)null);
+
+            var received = new List<(string, LogEvent)>();
+
+            var log = new LoggerConfiguration()
+                .WriteTo.Map<string>("Name", "anonymous", (name, wt) => wt.Sink(new DelegatingSink(e => received.Add((name, e)))))
                 .CreateLogger();
 
             log.Write(a);

--- a/test/Serilog.Sink.Map.Tests/Serilog.Sinks.Map.Tests.csproj
+++ b/test/Serilog.Sink.Map.Tests/Serilog.Sinks.Map.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;net452</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Map.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
 * `netstandard2.0` target
 * _Serilog_ 2.8 dependency
 * Use `ILogEventSink` instead of `Logger` internally
 * Fix usability of `Map(string...)`*

\* @skomis-mm I noticed that, after one of our earlier changes, the "simple" non-generic `Map()` overload could behave inconsistently between the _property missing_ and the _present but null_ cases; in particular:

```csharp
Some.LogEvent("Hello, {Name}!", null);
```

would use the default, while:

```csharp
Some.LogEvent("Hello, {Name}!", (object)null);
```

would end up using a `null` key (have to love `params object[]` 😅).

I've reviewed all of the overloads, I think things should work reasonably consistently/as expected in the cases I can find - keen to draw the line and ship a 1.0.